### PR TITLE
fix to candycane effect

### DIFF
--- a/neopixel-halloween-demo.1.py
+++ b/neopixel-halloween-demo.1.py
@@ -290,14 +290,15 @@ def colorAllColorGroup(colorObject):
 
 
 def candycane_custom(c1, c2, thisbright, delay, cycles):
-    index = 0
+    N6  = int(num_pixels/6)
+    N12 = int(num_pixels/12)
+
     for loop in range(cycles):
-        index = index + 1
-        N3  = int(num_pixels/3)
-        N6  = int(num_pixels/6)
-        N12 = int(num_pixels/12)
+        cSwap = c1
+        c1 = c2
+        c2 = cSwap
         for i in range(N6):
-            j0 = int((index + i + num_pixels - N12) % num_pixels)
+            j0 = int(( i + num_pixels - N12) % num_pixels)
             j1 = int((j0+N6) % num_pixels)
             j2 = int((j1+N6) % num_pixels)
             j3 = int((j2+N6) % num_pixels)


### PR DESCRIPTION
candycane has some logic intensive logic that it had to redraw the entire array of lights for just a few pixel changes each cycle. It was fixed in xmas, but not carried over to this file... (another point for converting this to a class and not files)